### PR TITLE
Show only feasible results in plots

### DIFF
--- a/src/mzn_bench/analysis/collect.py
+++ b/src/mzn_bench/analysis/collect.py
@@ -68,4 +68,5 @@ def read_csv(sols: str, stats: str):
     stats_df = pd.read_csv(stats)
     sols_df.data_file = sols_df.data_file.fillna("")
     stats_df.data_file = stats_df.data_file.fillna("")
+    stats_df = stats_df[(stats_df.status.eq("SATISFIED") | stats_df.status.eq("OPTIMAL_SOLUTION"))]
     return sols_df, stats_df


### PR DESCRIPTION
I'm not sure if this is the best way to handle this, but something must be done as `ERROR` results might miss the time stat, and `UNKNOWN` results might have a time equal to the timeout value which is misleading (we didn't get a solution at the timeout, after all)