### PR TITLE
Handle missing time stat (for ERROR statuses)

### DIFF
--- a/src/mzn_bench/analysis/report_status.py
+++ b/src/mzn_bench/analysis/report_status.py
@@ -26,7 +26,7 @@ def report_status(
 
             seen_status.add(row["status"])
             key = tuple(key)
-            time = float(row["time"])
+            time = float(row["time"] if row["time"] else 0)
             if key not in table:
                 table[key] = {row["status"]: [time]}
             elif row["status"] not in table[tuple(key)]:

--- a/src/mzn_bench/analysis/report_status.py
+++ b/src/mzn_bench/analysis/report_status.py
@@ -26,7 +26,7 @@ def report_status(
 
             seen_status.add(row["status"])
             key = tuple(key)
-            time = float(row["time"] if row["time"] else 0)
+            time = float(0 if row["time"] == "" else row["time"])
             if key not in table:
                 table[key] = {row["status"]: [time]}
             elif row["status"] not in table[tuple(key)]:


### PR DESCRIPTION
An ERROR might occur before a time is output, in which case our best
guess is that it happened at time 0. This keeps the --avg-time somewhat
consistent even for ERROR statuses.