### PR TITLE
Skip checks on ERROR statuses

### DIFF
--- a/src/mzn_bench/pytest/check_statuses.py
+++ b/src/mzn_bench/pytest/check_statuses.py
@@ -30,11 +30,16 @@ class StatsItem(pytest.Item):
         self.stats = stats
 
     def runtest(self):
-        method = Method[self.stats["method"].upper()]
         status = Status[self.stats["status"]]
         key = "{}_{}_{}".format(
             self.stats["problem"], self.stats["model"], self.stats["data_file"]
         )
+        if status is Status.ERROR:
+            pytest.skip(
+                "skipping {} as status was ERROR".format(key)
+            )
+
+        method = Method[self.stats["method"].upper()]
         if status is Status.UNSATISFIABLE:
             is_satisfiable = self.config.cache.get("sat/" + key, False)
             assert not is_satisfiable, "Incorrect UNSAT status"


### PR DESCRIPTION
The method field might be missing for solutions with an `ERROR` status, which this change handles by just skipping the test case for errors. However, this raises the question how to see an `ERROR` status, as you can argue whether it passes, skips or fals the test. An error can be a bug (in which case it might be good if it the test case is failed) or it can be the memory running out (which is not really a failure, like an `UNKNOWN` is not if the timelimit runs out). Let me know what would be a good procedure for this :+1: 