### PR TITLE
Add command to compare configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,13 @@ and combine them for further use:
 
 The following scripts filter and tabulate specific statistics.
 
-- `mzn-bench report-status <statistics.csv>` - This script will report the
+- `mzn-bench report-status <statistics.csv>` - This command will report the
   number of occurrences of the various solving status of your MiniZinc tasks.
   Please consult the `-h` flag to display all options.
+- `mzn-bench compare-configurations <statistics.csv> <before_conf> <after_conf>` - This command reports on the differences of the achieved
+  results between two configurations (differences in status, runtime, and
+  objective). You can adjust the changes deemed significant with the
+  `--time-delta` and `--objective-delta` flag. You can use the `--output-mode json` option to ensure the output can be easily parsed by other programs.
 
 ### Solution checking
 

--- a/src/mzn_bench/analysis/analyse_changes.py
+++ b/src/mzn_bench/analysis/analyse_changes.py
@@ -91,7 +91,7 @@ class PerformanceChanges:
         output += (
             f"- Status Changes: {n_status_changes} ({'conflicts: ' + str(n_bad_status_changes) + ', ' if n_bad_status_changes > 0 else ''}positive: {n_pos_status_changes})\n"
             f"- Runtime Changes: {len(self.time_changes)} (positive: {len([x for x in self.time_changes if (x[3] - x[2]) / x[2] < 0])})\n"
-            f"- Objective Changes: {len(self.obj_changes)} (posxive: {len([x for x in self.obj_changes if obj_sort_key(x) > 0])})\n"
+            f"- Objective Changes: {len(self.obj_changes)} (positive: {len([x for x in self.obj_changes if obj_sort_key(x) > 0])})\n"
         )
         output += "\n\n"
 

--- a/src/mzn_bench/analysis/analyse_changes.py
+++ b/src/mzn_bench/analysis/analyse_changes.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+import csv
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class PerformanceChanges:
+    time_delta: float
+    obj_delta: float
+    # (from_status, to_status) -> (model, datafile)
+    status_changes: dict[tuple[str, str], list[tuple[str, str]]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    # model, datafile, from_time, to_time
+    time_changes: list[tuple[str, str, float, float]] = field(default_factory=list)
+    # model, datafile, from_obj, to_obj, maximise?
+    obj_changes: list[tuple[str, str, float, float, bool]] = field(default_factory=list)
+    # model, datafile
+    missing_instances: list[tuple[str, str]] = field(default_factory=list)
+
+    def __str__(self):
+        n_status_changes = sum([len(li) for key, li in self.status_changes.items()])
+        n_pos_status_changes = 0
+        n_bad_status_changes = 0
+
+        pos_status_changes = [
+            ("ERROR", "SATISFIED"),
+            ("ERROR", "UNSATISFIABLE"),
+            ("ERROR", "OPTIMAL_SOLUTION"),
+            ("ERROR", "UNKNOWN"),
+            ("UNKNOWN", "SATISFIED"),
+            ("UNKNOWN", "UNSATISFIABLE"),
+            ("UNKNOWN", "OPTIMAL_SOLUTION"),
+            ("SATISFIED", "OPTIMAL_SOLUTION"),
+        ]
+
+        conflicting_status_changes = [
+            ("UNSATISFIABLE", "SATISFIED"),
+            ("SATISFIED", "UNSATISFIABLE"),
+            ("UNSATISFIABLE", "OPTIMAL_SOLUTION"),
+            ("OPTIMAL_SOLUTION", "UNSATISFIABLE"),
+        ]
+
+        stat_bad_str = ""
+        stat_pos_str = ""
+        stat_neg_str = ""
+
+        for change, li in self.status_changes.items():
+            s = f"{change[0]} -> {change[1]}:\n"
+            for i in li:
+                s += f"  - {i[0]} {i[1]}\n"
+            if change in conflicting_status_changes:
+                n_bad_status_changes += len(li)
+                stat_bad_str += s
+            elif change in pos_status_changes:
+                n_pos_status_changes += len(li)
+                stat_pos_str += s
+            else:
+                stat_neg_str += s
+
+        if stat_bad_str != "":
+            stat_bad_str = (
+                "Conflicting Status Changes:\n---------------------------\n"
+                + stat_bad_str
+            )
+        if stat_pos_str != "":
+            stat_pos_str = (
+                "Positive Status Changes:\n------------------------\n" + stat_pos_str
+            )
+        if stat_neg_str != "":
+            stat_neg_str = (
+                "Negative Status Changes:\n------------------------\n" + stat_neg_str
+            )
+
+        output = (
+            f"Summary:\n"
+            f"========\n"
+            f"- Status Changes: {n_status_changes} ({'conflicts: ' + str(n_bad_status_changes) + ', ' if n_bad_status_changes > 0 else ''}positive: {n_pos_status_changes})\n"
+            f"- Runtime Changes: {len(self.time_changes)} (positive: {len([x for x in self.time_changes if (x[3] - x[2]) / x[2] < 0])})\n"
+            f"- Objective Changes: {len(self.obj_changes)} (posxive: {len([x for x in self.obj_changes if (1 if x[4] else -1) * (x[3] - x[2]) / x[2] > 0])})\n"
+        )
+        if len(self.missing_instances) > 0:
+            f"- Missing instances: {len(self.missing_instances)}\n"
+        output += "\n\n"
+
+        output += (
+            f"Status Changes:\n===============\n{stat_bad_str}\n{stat_neg_str}\n{stat_pos_str}\n"
+            if n_status_changes > 0
+            else ""
+        )
+
+        if len(self.time_changes) > 0:
+            output += f"Timing Changes (>±{self.time_delta * 100:.1f}%):\n=========================\n"
+            time_li = sorted(
+                self.time_changes, key=lambda it: (it[3] - it[2]) / it[2], reverse=True
+            )
+            for it in time_li:
+                output += f"- ({(it[3] - it[2]) / it[2] * 100:.1f}%: {it[2]:.1f}s -> {it[3]:.1f}s) {it[0]} {it[1]}\n"
+            output += "\n"
+
+        if len(self.obj_changes) > 0:
+            output += f"Objective Changes (>±{self.obj_delta * 100:.1f}%):\n=========================\n"
+            obj_li = sorted(
+                self.obj_changes,
+                key=lambda it: (1 if it[4] else -1) * (it[3] - it[2]) / it[2],
+            )
+            for it in obj_li:
+                output += f"- ({(it[3] - it[2]) / it[2] * 100:.1f}%: {'MAX' if it[4] else 'MIN'} {it[2]:.2f} -> {it[3]:.2f}) {it[0]} {it[1]}\n"
+
+        if len(self.missing_instances) > 0:
+            output += "Missing Instances:\n==================\n"
+            for it in self.missing_instances:
+                output += f"- {it[0]} {it[1]}"
+
+        return output
+
+
+def compare_configurations(
+    statistics: Path, from_conf: str, to_conf: str, time_delta: float, obj_delta: float
+) -> PerformanceChanges:
+    from_stats = {}
+    to_stats = {}
+
+    with statistics.open() as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            if row["configuration"] == from_conf:
+                from_stats[(row["model"], row["data_file"])] = (
+                    row["status"],
+                    float(0 if row["time"] == "" else row["time"]),
+                    float(math.nan if row["objective"] == "" else row["objective"]),
+                    row["method"],
+                )
+            elif row["configuration"] == to_conf:
+                to_stats[(row["model"], row["data_file"])] = (
+                    row["status"],
+                    float(0 if row["time"] == "" else row["time"]),
+                    float(math.nan if row["objective"] == "" else row["objective"]),
+                )
+
+    changes = PerformanceChanges(time_delta, obj_delta)
+
+    for key, from_val in from_stats.items():
+        to_val = to_stats.get(key, None)
+        if to_val is None:
+            changes.missing_instances.append(key)
+        elif from_val[0] != to_val[0]:
+            changes.status_changes[(from_val[0], to_val[0])].append(key)
+        elif from_val[0] == "OPTIMAL_SOLUTION" or (
+            from_val[0] == "SATISFIED" and from_val[3] == "satisfy"
+        ):
+            time_change = (to_val[1] - from_val[1]) / from_val[1]
+            if abs(time_change) > time_delta:
+                changes.time_changes.append((key[0], key[1], from_val[1], to_val[1]))
+        elif from_val[0] == "SATISFIED" and from_val[3] != "satisfy":
+            obj_change = (to_val[2] - from_val[2]) / from_val[2]
+            if abs(obj_change) > obj_delta:
+                changes.obj_changes.append(
+                    (key[0], key[1], from_val[2], to_val[2], from_val[3] == "maximize")
+                )
+
+    return changes

--- a/src/mzn_bench/analysis/analyse_changes.py
+++ b/src/mzn_bench/analysis/analyse_changes.py
@@ -177,7 +177,8 @@ def compare_configurations(
         elif from_val[0] == "OPTIMAL_SOLUTION" or (
             from_val[0] == "SATISFIED" and from_val[3] == "satisfy"
         ):
-            time_change = (to_val[1] - from_val[1]) / from_val[1]
+            time_div = from_val[1] if from_val[1] != 0.0 else 0.1
+            time_change = (to_val[1] - from_val[1]) / time_div
             if (
                 from_val[0] == "OPTIMAL_SOLUTION"
                 and abs(from_val[2] - to_val[2]) > SAME_DELTA
@@ -186,7 +187,8 @@ def compare_configurations(
             elif abs(time_change) > time_delta:
                 changes.time_changes.append((key[0], key[1], from_val[1], to_val[1]))
         elif from_val[0] == "SATISFIED" and from_val[3] != "satisfy":
-            obj_change = (to_val[2] - from_val[2]) / from_val[2]
+            obj_div = from_val[2] if from_val[2] != 0.0 else 0.1
+            obj_change = (to_val[2] - from_val[2]) / obj_div
             if abs(obj_change) > obj_delta:
                 changes.obj_changes.append(
                     (key[0], key[1], from_val[2], to_val[2], from_val[3] == "maximize")

--- a/src/mzn_bench/cli.py
+++ b/src/mzn_bench/cli.py
@@ -244,5 +244,46 @@ def report_status(
         exit(1)
 
 
+@main.command()
+@click.argument(
+    "statistics", metavar="stats_file", type=click.Path(exists=True, file_okay=True)
+)
+@click.argument(
+    "from_conf",
+    metavar="from_conf",
+)
+@click.argument(
+    "to_conf",
+    metavar="to_conf",
+)
+@click.option(
+    "--time-delta",
+    default=0.1,
+    type=float,
+    help="Fraction of time change considered to be significant",
+)
+@click.option(
+    "--obj-delta",
+    default=0.1,
+    type=float,
+    help="Fraction of objective value change considered to be significant",
+)
+def compare_configurations(
+    statistics: str,
+    from_conf: str,
+    to_conf: str,
+    time_delta: float,
+    obj_delta: float,
+):
+    """Show all significant performance changes between two configurations"""
+    try:
+        from .analysis.analyse_changes import compare_configurations as fn
+
+        print(fn(Path(statistics), from_conf, to_conf, time_delta, obj_delta))
+    except ImportError:
+        click.echo(IMPORT_ERROR, err=True)
+        exit(1)
+
+
 if __name__ == "__main__":
     main()

--- a/src/mzn_bench/cli.py
+++ b/src/mzn_bench/cli.py
@@ -270,8 +270,8 @@ def report_status(
 )
 @click.option(
     "--output-mode",
-    type=click.Choice(["", "json"], case_sensitive=False),
-    default="",
+    type=click.Choice(["human", "json"], case_sensitive=False),
+    default="human",
     help="The format used in the output.",
 )
 def compare_configurations(
@@ -287,7 +287,7 @@ def compare_configurations(
         from .analysis.analyse_changes import compare_configurations as fn
 
         result = fn(Path(statistics), from_conf, to_conf, time_delta, obj_delta)
-        if output_mode != "":
+        if output_mode != "human":
             result = result.serialise(output_mode)
 
         print(result)

--- a/src/mzn_bench/cli.py
+++ b/src/mzn_bench/cli.py
@@ -268,18 +268,29 @@ def report_status(
     type=float,
     help="Fraction of objective value change considered to be significant",
 )
+@click.option(
+    "--output-mode",
+    type=click.Choice(["", "json"], case_sensitive=False),
+    default="",
+    help="The format used in the output.",
+)
 def compare_configurations(
     statistics: str,
     from_conf: str,
     to_conf: str,
     time_delta: float,
     obj_delta: float,
+    output_mode: str,
 ):
     """Show all significant performance changes between two configurations"""
     try:
         from .analysis.analyse_changes import compare_configurations as fn
 
-        print(fn(Path(statistics), from_conf, to_conf, time_delta, obj_delta))
+        result = fn(Path(statistics), from_conf, to_conf, time_delta, obj_delta)
+        if output_mode != "":
+            result = result.serialise(output_mode)
+
+        print(result)
     except ImportError:
         click.echo(IMPORT_ERROR, err=True)
         exit(1)


### PR DESCRIPTION
Adds the `compare-configurations` command that takes two configurations from the statistics files and show any significant changes between the two. For example:

```
Summary:
========
- Status Changes: 14 (positive: 6)
- Runtime Changes: 18 (positive: 10)
- Objective Changes: 1 (posxive: 1)


Status Changes:
===============

Negative Status Changes:
------------------------
OPTIMAL_SOLUTION -> SATISFIED:
  - data/mznc2020/skill-allocation/skill_allocation_only.mzn data/mznc2020/skill-allocation/skill_allocation_mzn_1m_1.dzn
SATISFIED -> UNKNOWN:
  - data/mznc2020/stable-goods/stable-goods-solution.mzn data/mznc2020/stable-goods/s-d6.dzn
  - data/mznc2019/median-string/median_string_dp.mzn data/mznc2019/median-string/p2_10_8-3.dzn
  - data/mznc2019/rotating-workforce/rotating-workforce.mzn data/mznc2019/rotating-workforce/Example789.dzn
  - data/mznc2020/skill-allocation/skill_allocation_only.mzn data/mznc2020/skill-allocation/skill_allocation_mzn_2m_3.dzn
OPTIMAL_SOLUTION -> UNKNOWN:
  - data/mznc2020/skill-allocation/skill_allocation_only.mzn data/mznc2020/skill-allocation/skill_allocation_mzn_2m_1.dzn
  - data/mznc2020/sdn-chain/model.mzn data/mznc2020/sdn-chain/d10n780-2.dzn
  - data/mznc2020/sdn-chain/model.mzn data/mznc2020/sdn-chain/d10n780-1.dzn

Positive Status Changes:
------------------------
UNKNOWN -> OPTIMAL_SOLUTION:
  - data/mznc2019/hrc/hrc.mzn data/mznc2019/hrc/exp1-1-5110.dzn
  - data/mznc2020/hoist-benchmark-for-minizinc/hoist-benchmark.mzn data/mznc2020/hoist-benchmark-for-minizinc/PU_2_8_1.dzn
ERROR -> UNKNOWN:
  - data/mznc2020/pentominoes/pentominoes-int.mzn data/mznc2020/pentominoes/04.dzn
SATISFIED -> OPTIMAL_SOLUTION:
  - data/mznc2020/racp/racp.mzn data/mznc2020/racp/j30_26_2_1.0.dzn
UNKNOWN -> SATISFIED:
  - data/mznc2020/cable_tree_wiring/ctw.mzn data/mznc2020/cable_tree_wiring/R046.dzn
  - data/mznc2020/tower_challenge/tower.mzn data/mznc2020/tower_challenge/tower_070_070_15_070-04.dzn

Timing Changes (>±10.0%):
=========================
- (205.2%: 14.2s -> 43.4s) data/mznc2019/zephyrus/zephyrus.mzn data/mznc2019/zephyrus/12__10__8__3.dzn
- (127.1%: 65.3s -> 148.4s) data/mznc2019/amaze/amaze3.mzn data/mznc2019/amaze/2012-03-29.dzn
- (112.4%: 7.5s -> 15.8s) data/mznc2019/zephyrus/zephyrus.mzn data/mznc2019/zephyrus/12__8__6__3.dzn
- (98.4%: 431.6s -> 856.3s) data/mznc2020/sdn-chain/model.mzn data/mznc2020/sdn-chain/d24n600-3.dzn
- (57.3%: 105.6s -> 166.1s) data/mznc2019/rotating-workforce/rotating-workforce.mzn data/mznc2019/rotating-workforce/Example1337.dzn
- (28.6%: 23.7s -> 30.5s) data/mznc2019/zephyrus/zephyrus.mzn data/mznc2019/zephyrus/14__6__6__3.dzn
- (23.7%: 30.0s -> 37.1s) data/mznc2019/zephyrus/zephyrus.mzn data/mznc2019/zephyrus/14__10__6__3.dzn
- (14.9%: 163.0s -> 187.3s) data/mznc2019/triangular/triangular.mzn data/mznc2019/triangular/n10.dzn
- (-13.8%: 18.5s -> 15.9s) data/mznc2019/zephyrus/zephyrus.mzn data/mznc2019/zephyrus/12__6__6__3.dzn
- (-17.5%: 1.6s -> 1.3s) data/mznc2019/ptv/pax_model.mzn data/mznc2019/ptv/pax_period_20_2b.dzn
- (-25.0%: 1.8s -> 1.4s) data/mznc2019/ptv/pax_model.mzn data/mznc2019/ptv/pax_period_20_5b.dzn
- (-25.3%: 97.5s -> 72.9s) data/mznc2019/hrc/hrc.mzn data/mznc2019/hrc/exp1-1-5460.dzn
- (-25.7%: 1.8s -> 1.4s) data/mznc2019/ptv/pax_model.mzn data/mznc2019/ptv/pax_period_20_3b.dzn
- (-53.9%: 946.1s -> 436.5s) data/mznc2020/hoist-benchmark-for-minizinc/hoist-benchmark.mzn data/mznc2020/hoist-benchmark-for-minizinc/PU_1_2_2.dzn
- (-60.7%: 366.0s -> 143.7s) data/mznc2019/ptv/pax_model.mzn data/mznc2019/ptv/pax_period_20_1c.dzn
- (-73.9%: 77.2s -> 20.1s) data/mznc2019/fox-geese-corn/foxgeesecorn.mzn data/mznc2019/fox-geese-corn/foxgeesecorn_54.dzn
- (-79.7%: 65.0s -> 13.2s) data/mznc2020/is/model.mzn data/mznc2020/is/v1HjuSBQMb.dzn
- (-81.0%: 584.1s -> 110.8s) data/mznc2019/hrc/hrc.mzn data/mznc2019/hrc/exp1-1-5425.dzn

Objective Changes (>±10.0%):
=========================
- (-14.9%: MIN 47.00 -> 40.00) data/mznc2020/minimal-decision-sets/sparse_mds.mzn data/mznc2020/minimal-decision-sets/backache_train4.dzn
```