### PR TITLE
Use configuration's driver to instantiate Solver

### DIFF
--- a/src/mzn_bench/mzn_slurm.py
+++ b/src/mzn_bench/mzn_slurm.py
@@ -46,6 +46,9 @@ class Configuration:
 
     @classmethod
     def from_dict(cls, obj):
+        if obj["minizinc"] is not None:
+            obj["minizinc"] = Path(obj["minizinc"])
+            minizinc.CLI.CLIDriver(obj["minizinc"]).make_default()
         field_names = set(f.name for f in fields(minizinc.Solver))
         identifier = obj.pop("sol_ident")
         if identifier == "":
@@ -70,8 +73,6 @@ class Configuration:
             if version is not None:
                 assert obj["solver"].version == version
 
-        if obj["minizinc"] is not None:
-            obj["minizinc"] = Path(obj["minizinc"])
         return cls(**obj)
 
 


### PR DESCRIPTION
Otherwise, the default driver (on the user's PATH) might not have that particular solver configuration.

I'm not 100% sure how to solve this except setting the default driver for each instance. The `load` function does not support a driver argument.