### PR TITLE
Opinionated reformatting of report-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ The following scripts filter and tabulate specific statistics.
 
 - `mzn-bench report-status <statistics.csv>` - This command will report the
   number of occurrences of the various solving status of your MiniZinc tasks.
+  Note that the number of satisfied instances is reported as `A + B`, where `A`
+  is the number of optimisation instances that reach a solution not proven
+  optimal and `B` is the number of satisfaction instance finding a solution.
   Please consult the `-h` flag to display all options.
 - `mzn-bench compare-configurations <statistics.csv> <before_conf> <after_conf>` - This command reports on the differences of the achieved
   results between two configurations (differences in status, runtime, and

--- a/src/mzn_bench/analysis/report_status.py
+++ b/src/mzn_bench/analysis/report_status.py
@@ -73,7 +73,8 @@ def report_status(
     ]
 
     output = []
-    for key, row in table.items():
+    for key in sorted(table):
+        row = table[key]
         line = list(key)
         for s in status_order:
             if s in seen_status:

--- a/src/mzn_bench/analysis/report_status.py
+++ b/src/mzn_bench/analysis/report_status.py
@@ -80,13 +80,18 @@ def report_status(
             if s in seen_status:
                 if s not in row:
                     o = 0
-                elif avg != "" and s in [
+                elif avg and s in [
                     Status.OPTIMAL_SOLUTION,
                     Status.UNSATISFIABLE,
                 ]:
                     o = f"{len(row[s])} ({sum(row[s]) / len(row[s]) :.2f}s)"
-                elif avg != "" and s == Status.SATISFIED:
-                    o = f"{row[s][0]} + {len(row[s][1])} ({sum(row[s][1]) / len(row[s][1]) :.2f}s)"
+                elif s == Status.SATISFIED:
+                    if avg:
+                        o = f"{row[s][0]-len(row[s][1])} + {len(row[s][1])}"
+                        if len(row[s][1]) > 0:
+                            o += f" ({sum(row[s][1]) / len(row[s][1]) :.2f}s)"
+                    else:
+                        o = f"{row[s][0]-row[s][1]} + {row[s][1]}"
                 else:
                     o = row[s]
                 line.append(o)


### PR DESCRIPTION
This is somewhat an opinionated PR that changes the way the table of `report-status` is formatted.

```
+----------------------------------------------+------------------+---------------+-----------------+---------+-------+
|                configuration                 | OPTIMAL_SOLUTION | UNSATISFIABLE |    SATISFIED    | UNKNOWN | ERROR |
+----------------------------------------------+------------------+---------------+-----------------+---------+-------+
| mzn_sat-open_wbo-binary-no_half_reifications |   28 (147.65s)   |  7 (138.46s)  | 25 + 7 (85.51s) |   16    |  20   |
| mzn_sat-open_wbo-direct-no_half_reifications |   19 (153.77s)   |       0       | 11 + 5 (0.33s)  |    5    |  54   |
|   mzn_sat-open_wbo-mixed-half_reifications   |   25 (210.76s)   |  4 (204.97s)  | 23 + 7 (45.58s) |   13    |  33   |
|  mzn_sat-open_wbo-direct-half_reifications   |   19 (130.43s)   |       0       | 11 + 5 (0.34s)  |    5    |  53   |
| mzn_sat-open_wbo-order-no_half_reifications  |   24 (184.03s)   |       0       |  9 + 5 (0.26s)  |   10    |  43   |
|   mzn_sat-open_wbo-order-half_reifications   |   23 (123.83s)   |       0       | 10 + 5 (0.29s)  |   10    |  41   |
|  mzn_sat-open_wbo-binary-half_reifications   |   29 (185.30s)   |  7 (90.21s)   | 24 + 7 (88.25s) |   15    |  20   |
| mzn_sat-open_wbo-mixed-no_half_reifications  |   26 (249.86s)   |  4 (112.59s)  | 21 + 7 (55.25s) |   10    |  36   |
+----------------------------------------------+------------------+---------------+-----------------+---------+-------+
```


The most important change is that SATISFIED instances are now reported in two parts, `A + B (avg)`, where part `A` is the number of solutions that found a solution for a optimisation problem and part `B` is the number of completed satisfaction problems.

I also changed the data structure to not keep as much extra information. Especially for big tests this should help a bit.

The second change is that I changed the weird hack that I used to get a somewhat decent order of statuses. I now have an explicit order defined in the script.

Again, to make this easier I change the underlying data structure to use the Python Enums. This ensures that distinguishing between them happens correctly, but should also make them tiny in comparison to the string storage.