### PR TITLE
Fix minizinc python code to match upstream changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     install_requires=[
-        "minizinc",
+        "minizinc>=0.7,<1",
         "ruamel.yaml",
         "click>=7,<8",
     ],

--- a/src/mzn_bench/mzn_slurm.py
+++ b/src/mzn_bench/mzn_slurm.py
@@ -171,7 +171,8 @@ async def run_instance(
     try:
         driver = minizinc.default_driver
         if config.minizinc is not None:
-            driver = minizinc.CLI.CLIDriver(config.minizinc)
+            assert config.minizinc.exists()
+            driver = minizinc.Driver(config.minizinc)
         instance = minizinc.Instance(config.solver, minizinc.Model(model), driver)
         if data is not None:
             instance.add_file(data, parse_data=False)
@@ -247,7 +248,8 @@ if __name__ == "__main__":
         config = configurations[task_id]
         # TODO: workaround because we might not know the solver in the system MiniZinc
         if config["minizinc"] is not None:
-            minizinc.CLI.CLIDriver(Path(config["minizinc"])).make_default()
+            assert config["minizinc"].exists()
+            minizinc.Driver(Path(config["minizinc"])).make_default()
         config = Configuration.from_dict(config)
 
         filename = f"{row}_{config.name}"


### PR DESCRIPTION
This PR fixes the mzn-bench tool to work with the upcoming changes in the MiniZinc Python package.

These changes should be merged after the next MiniZinc Python release