### PR TITLE
Fix pytest deprecation warnings

### DIFF
--- a/src/mzn_bench/pytest/check_solutions.py
+++ b/src/mzn_bench/pytest/check_solutions.py
@@ -139,7 +139,7 @@ class SolutionChecker:
         if path.basename.endswith("_sol.yml"):
             return SolFile.from_parent(
                 parent,
-                fspath=path,
+                path=Path(path),
                 checker=self.checker,
                 num_check=self.num_check,
                 base_dir=Path(self.base_dir),

--- a/src/mzn_bench/pytest/check_statuses.py
+++ b/src/mzn_bench/pytest/check_statuses.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 import pytest
 from minizinc import Method, Status
 from ruamel.yaml import YAML
+from pathlib import Path
 
 yaml = YAML(typ="unsafe")
 
@@ -57,4 +58,4 @@ class StatsItem(pytest.Item):
 
 def pytest_collect_file(parent, path):
     if path.basename.endswith("_stats.yml"):
-        return StatsFile.from_parent(parent, fspath=path)
+        return StatsFile.from_parent(parent, path=Path(path))


### PR DESCRIPTION
Fix [this](https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path) warning.