### PR TITLE
Fix comparing satisfaction results which lack objective

### DIFF
--- a/src/mzn_bench/analysis/analyse_changes.py
+++ b/src/mzn_bench/analysis/analyse_changes.py
@@ -211,15 +211,15 @@ def compare_configurations(
             if row["configuration"] == from_conf:
                 from_stats[(row["model"], row["data_file"])] = (
                     row["status"],
-                    float(0 if row["time"] == "" else row["time"]),
-                    float(math.nan if row["objective"] == "" else row["objective"]),
+                    float(row["time"]),
+                    float(row.get("objective",math.nan)),
                     row["method"],
                 )
             elif row["configuration"] == to_conf:
                 to_stats[(row["model"], row["data_file"])] = (
                     row["status"],
-                    float(0 if row["time"] == "" else row["time"]),
-                    float(math.nan if row["objective"] == "" else row["objective"]),
+                    float(row["time"]),
+                    float(row.get("objective",math.nan)),
                 )
 
     changes = PerformanceChanges(time_delta, obj_delta)

--- a/src/mzn_bench/analysis/analyse_changes.py
+++ b/src/mzn_bench/analysis/analyse_changes.py
@@ -5,6 +5,7 @@ import math
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Tuple,Dict,List
 
 # The difference in objectives for them to be considered the same
 SAME_DELTA = 1e-6
@@ -33,17 +34,17 @@ class PerformanceChanges:
     time_delta: float
     obj_delta: float
     # (from_status, to_status) -> (model, datafile)
-    status_changes: dict[tuple[str, str], list[tuple[str, str]]] = field(
+    status_changes: Dict[Tuple[str, str], List[Tuple[str, str]]] = field(
         default_factory=lambda: defaultdict(list)
     )
     # model, datafile, from_time, to_time
-    time_changes: list[tuple[str, str, float, float]] = field(default_factory=list)
+    time_changes: List[Tuple[str, str, float, float]] = field(default_factory=list)
     # model, datafile, from_obj, to_obj, maximise?
-    obj_changes: list[tuple[str, str, float, float, bool]] = field(default_factory=list)
+    obj_changes: List[Tuple[str, str, float, float, bool]] = field(default_factory=list)
     # model, datafile, from_obj, to_obj
-    obj_conflicts: list[tuple[str, str, float, float]] = field(default_factory=list)
+    obj_conflicts: List[Tuple[str, str, float, float]] = field(default_factory=list)
     # model, datafile
-    missing_instances: list[tuple[str, str]] = field(default_factory=list)
+    missing_instances: List[Tuple[str, str]] = field(default_factory=list)
 
     def __str__(self):
         obj_sort_key = lambda it: (1 if it[4] else -1) * (it[3] - it[2]) / it[2]

--- a/src/mzn_bench/analysis/analyse_changes.py
+++ b/src/mzn_bench/analysis/analyse_changes.py
@@ -5,7 +5,7 @@ import math
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Tuple,Dict,List
+from typing import Tuple, Dict, List
 
 # The difference in objectives for them to be considered the same
 SAME_DELTA = 1e-6

--- a/src/mzn_bench/analysis/analyse_changes.py
+++ b/src/mzn_bench/analysis/analyse_changes.py
@@ -198,6 +198,13 @@ class PerformanceChanges:
         assert method == "json"
         return json.dumps(as_dict)
 
+def read_row(row: dict):
+    return (
+        row["status"],
+        float(math.nan if row["time"] == "" else row["time"]),
+        float(row["objective"] if "objective" in row and row["objective"] != "" else math.nan),
+        row["method"],
+    )
 
 def compare_configurations(
     statistics: Path, from_conf: str, to_conf: str, time_delta: float, obj_delta: float
@@ -208,19 +215,11 @@ def compare_configurations(
     with statistics.open() as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
+            key = (row["model"], row["data_file"])
             if row["configuration"] == from_conf:
-                from_stats[(row["model"], row["data_file"])] = (
-                    row["status"],
-                    float(row["time"]),
-                    float(row.get("objective",math.nan)),
-                    row["method"],
-                )
+                from_stats[key] = read_row(row)
             elif row["configuration"] == to_conf:
-                to_stats[(row["model"], row["data_file"])] = (
-                    row["status"],
-                    float(row["time"]),
-                    float(row.get("objective",math.nan)),
-                )
+                to_stats[key] = read_row(row)
 
     changes = PerformanceChanges(time_delta, obj_delta)
 


### PR DESCRIPTION
I was getting a key error since `objective` is not guaranteed to be in the statistics (which is what this analysis looks at). On the other hand, `time` is guaranteed to have a value as far as I would expect.