### PR TITLE
Fix ruaml constructor error

### DIFF
--- a/src/mzn_bench/analysis/collect.py
+++ b/src/mzn_bench/analysis/collect.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Union
 import minizinc
-
 import ruamel.yaml
 
 STANDARD_KEYS = [
@@ -51,7 +50,7 @@ def collect_objectives(dirs: Iterable[Union[str, Path]]) -> List[Dict[str, Any]]
         path = (dir if isinstance(dir, Path) else Path(dir)).resolve()
         for file in path.rglob("*_sol.yml"):
             with file.open() as fp:
-                sols = ruamel.yaml.safe_load(fp)
+                sols = ruamel.yaml.load(fp, Loader=ruamel.yaml.Loader)
                 for sol in sols or []:
                     if "solution" not in sol:
                         continue
@@ -70,7 +69,7 @@ def collect_statistics(
         path = (dir if isinstance(dir, Path) else Path(dir)).resolve()
         for file in path.rglob("*_stats.yml"):
             with file.open() as fp:
-                stats = ruamel.yaml.safe_load(fp)
+                stats = ruamel.yaml.load(fp, Loader=ruamel.yaml.Loader)
                 if filter_stats is not None:
                     stats = {k: stats[k] for k in base_keys + filter_stats}
                 stats["run"] = path.name

--- a/src/mzn_bench/analysis/collect.py
+++ b/src/mzn_bench/analysis/collect.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Union
+import minizinc
 
 import ruamel.yaml
 


### PR DESCRIPTION
Without `minizinc` import, enums could not be deserialized from the yaml solution files