### PR TITLE
fix arguments and list concatenation

### DIFF
--- a/src/mzn_bench/analysis/report_status.py
+++ b/src/mzn_bench/analysis/report_status.py
@@ -90,6 +90,6 @@ def report_status(
 
     return tabulate(
         output,
-        headers=(keys + [s for s in status_order if s in seen_status]),
+        headers=(list(keys) + [s for s in status_order if s in seen_status]),
         tablefmt=tablefmt,
     )

--- a/src/mzn_bench/cli.py
+++ b/src/mzn_bench/cli.py
@@ -217,7 +217,7 @@ def check_statuses_(dir: str, pytest_args: Iterable[str]):
 
 @main.command()
 @click.option(
-    "--grouping",
+    "--groupings",
     help="Aggregate results over one or more groupings",
     type=click.Choice(["configuration", "run", "problem", "model", "data_file"]),
     default=["configuration"],

--- a/src/mzn_bench/cli.py
+++ b/src/mzn_bench/cli.py
@@ -217,7 +217,7 @@ def check_statuses_(dir: str, pytest_args: Iterable[str]):
 
 @main.command()
 @click.option(
-    "--groupings",
+    "--grouping",
     help="Aggregate results over one or more groupings",
     type=click.Choice(["configuration", "run", "problem", "model", "data_file"]),
     default=["configuration"],

--- a/src/mzn_bench/mzn_slurm.py
+++ b/src/mzn_bench/mzn_slurm.py
@@ -61,7 +61,7 @@ class Configuration:
                 }
             )
         elif identifier.endswith(".msc"):
-            obj["solver"] = minizinc.Solver.load(identifier)
+            obj["solver"] = minizinc.Solver.load(Path(identifier))
         else:
             # TODO: version tags should be handled correctly by MiniZinc Python
             version = None

--- a/src/mzn_bench/mzn_slurm.py
+++ b/src/mzn_bench/mzn_slurm.py
@@ -107,6 +107,7 @@ def schedule(
     timeout: timedelta,
     configurations: Iterable[Configuration],
     nodelist: Optional[Iterable[str]] = None,
+    partition: Optional[Iterable[str]] = None,
     output_dir: Path = Path.cwd() / "results",
     job_name: str = "MiniZinc Benchmark",
     cpus_per_task: int = 1,
@@ -154,6 +155,7 @@ def schedule(
         f"--cpus-per-task={cpus_per_task}",
         f"--mem={memory}",
         f"--nodelist={','.join(nodelist)}",
+        f"--partition={partition}",
         f"--array=1-{n_tasks}",
         f"--time={timeout + timedelta(minutes=1)}",  # Set hard timeout as failsafe
     ]

--- a/src/mzn_bench/mzn_slurm.py
+++ b/src/mzn_bench/mzn_slurm.py
@@ -107,7 +107,6 @@ def schedule(
     timeout: timedelta,
     configurations: Iterable[Configuration],
     nodelist: Optional[Iterable[str]] = None,
-    partition: Optional[Iterable[str]] = None,
     output_dir: Path = Path.cwd() / "results",
     job_name: str = "MiniZinc Benchmark",
     cpus_per_task: int = 1,
@@ -155,7 +154,6 @@ def schedule(
         f"--cpus-per-task={cpus_per_task}",
         f"--mem={memory}",
         f"--nodelist={','.join(nodelist)}",
-        f"--partition={partition}",
         f"--array=1-{n_tasks}",
         f"--time={timeout + timedelta(minutes=1)}",  # Set hard timeout as failsafe
     ]


### PR DESCRIPTION
fix argument for the method minizinc.Solver.load. 
Change from string to Path object. 
The document(https://python.minizinc.dev/en/latest/api.html#minizinc.solver.Solver.load) for the method is inconsistent with its implementation. 