### PR TITLE
update compare_configurations to output csv

### DIFF
--- a/src/mzn_bench/cli.py
+++ b/src/mzn_bench/cli.py
@@ -301,8 +301,10 @@ def compare_configurations(
         from .analysis.analyse_changes import compare_configurations as fn
 
         result = fn(Path(statistics), from_conf, to_conf, time_delta, obj_delta)
-        if output_mode != "human":
+        if output_mode == "json":
             result = result.serialise(output_mode)
+        if output_mode == "csv":
+            result = result.to_csv(output_mode)
 
         print(result)
     except ImportError:


### PR DESCRIPTION
Update ``compare_configurations`` command to output ``csv`` file. 

There are also two updates for easy comparison of configurations: 
- include three new pairs of ``(before_status, after_status)`` values in ``CONFLICT_STATUS_CHANGES`` 
- include the ``maximise`` attribute in the case of objective conflict to identify whether the second configuration is over-constrained or under-constrained compared with the first configuration 